### PR TITLE
Flush writer buffer after writing a log entry

### DIFF
--- a/log4jSyslogWriter64k/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
+++ b/log4jSyslogWriter64k/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
@@ -355,6 +355,8 @@ public class SyslogAppender64k extends AppenderSkeleton {
 				}
 			}
 		}
+
+		syslogQuietWriter.flush();
 	}
 
 	/**


### PR DESCRIPTION
This makes sure, that even less often used appender instances still write their data in mean time.