### PR TITLE
Add TCP socket timeout

### DIFF
--- a/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
+++ b/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
@@ -7,6 +7,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -213,6 +214,8 @@ public class SyslogAppender64k extends AppenderSkeleton {
 
 	private Optional<SocketFactory> tcpSocketFactory = Optional.empty();
 
+	private Optional<Duration> tcpSocketTimeout = Optional.of(Duration.ofMinutes(1));
+
 	/**
 	 * Max length in bytes of a message.
 	 */
@@ -387,7 +390,9 @@ public class SyslogAppender64k extends AppenderSkeleton {
 			break;
 		case PROTOCOL_TCP:
 			this.syslogQuietWriter
-					= Optional.of(new SyslogQuietWriter(new SyslogTcpWriter64k(syslogHost, charset, tcpSocketFactory),
+					= Optional.of(
+							new SyslogQuietWriter(
+									new SyslogTcpWriter64k(syslogHost, charset, tcpSocketFactory, tcpSocketTimeout),
 							syslogFacility,
 							errorHandler));
 			break;
@@ -567,6 +572,14 @@ public class SyslogAppender64k extends AppenderSkeleton {
 
 	public void setTcpSocketFactory(final SocketFactory tcpSocketFactory) {
 		this.tcpSocketFactory = Optional.ofNullable(tcpSocketFactory);
+	}
+
+	public Optional<Duration> getTcpSocketTimeout() {
+		return tcpSocketTimeout;
+	}
+
+	public void setTcpSocketTimeout(final Duration tcpSocketTimeout) {
+		this.tcpSocketTimeout = Optional.ofNullable(tcpSocketTimeout);
 	}
 
 	/**

--- a/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
+++ b/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
@@ -577,7 +577,7 @@ public class SyslogAppender64k extends AppenderSkeleton {
 	}
 
 	public void setTcpSocketTimeout(final Duration tcpSocketTimeout) {
-		this.tcpSocketTimeout = tcpSocketTimeout;
+		this.tcpSocketTimeout = tcpSocketTimeout == null ? Duration.ZERO : tcpSocketTimeout;
 	}
 
 	/**

--- a/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
+++ b/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
@@ -389,12 +389,10 @@ public class SyslogAppender64k extends AppenderSkeleton {
 					new SyslogQuietWriter(new SyslogUdpWriter64k(syslogHost, charset), syslogFacility, errorHandler));
 			break;
 		case PROTOCOL_TCP:
-			this.syslogQuietWriter
-					= Optional.of(
-							new SyslogQuietWriter(
-									new SyslogTcpWriter64k(syslogHost, charset, tcpSocketFactory, tcpSocketTimeout),
-							syslogFacility,
-							errorHandler));
+			this.syslogQuietWriter = Optional.of(new SyslogQuietWriter(
+					new SyslogTcpWriter64k(syslogHost, charset, tcpSocketFactory, tcpSocketTimeout),
+					syslogFacility,
+					errorHandler));
 			break;
 		default:
 			throw new IllegalArgumentException(String.format("Unexpected protocol: %s", protocol));

--- a/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
+++ b/src/main/java/com/github/loggly/log4j/SyslogAppender64k.java
@@ -214,7 +214,7 @@ public class SyslogAppender64k extends AppenderSkeleton {
 
 	private Optional<SocketFactory> tcpSocketFactory = Optional.empty();
 
-	private Optional<Duration> tcpSocketTimeout = Optional.of(Duration.ofMinutes(1));
+	private Duration tcpSocketTimeout = Duration.ofMinutes(1);
 
 	/**
 	 * Max length in bytes of a message.
@@ -572,12 +572,12 @@ public class SyslogAppender64k extends AppenderSkeleton {
 		this.tcpSocketFactory = Optional.ofNullable(tcpSocketFactory);
 	}
 
-	public Optional<Duration> getTcpSocketTimeout() {
+	public Duration getTcpSocketTimeout() {
 		return tcpSocketTimeout;
 	}
 
 	public void setTcpSocketTimeout(final Duration tcpSocketTimeout) {
-		this.tcpSocketTimeout = Optional.ofNullable(tcpSocketTimeout);
+		this.tcpSocketTimeout = tcpSocketTimeout;
 	}
 
 	/**

--- a/src/main/java/com/github/loggly/log4j/helpers/SyslogTcpWriter64k.java
+++ b/src/main/java/com/github/loggly/log4j/helpers/SyslogTcpWriter64k.java
@@ -23,7 +23,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class SyslogTcpWriter64k extends SyslogWriter64k {
 	private final Optional<SocketFactory> socketFactory;
 
-	private final Optional<Duration> socketTimeout;
+	private final Duration socketTimeout;
 
 	private final AtomicReference<Socket> socket = new AtomicReference<>(null);
 
@@ -32,7 +32,7 @@ public class SyslogTcpWriter64k extends SyslogWriter64k {
 	public SyslogTcpWriter64k(final String syslogHost,
 			final Charset charset,
 			final Optional<SocketFactory> socketFactory,
-			final Optional<Duration> socketTimeout) {
+			final Duration socketTimeout) {
 		super(syslogHost, charset);
 
 		this.socketFactory = socketFactory;
@@ -57,8 +57,7 @@ public class SyslogTcpWriter64k extends SyslogWriter64k {
 				final Socket socketToSet = socketFactory.isPresent()
 						? socketFactory.get().createSocket(getSyslogHost(), getSyslogPort())
 						: new Socket(getSyslogHost(), getSyslogPort());
-				socketToSet
-						.setSoTimeout(socketTimeout.map(duration -> (int) duration.get(ChronoUnit.MILLIS)).orElse(0));
+				socketToSet.setSoTimeout((int) socketTimeout.get(ChronoUnit.MILLIS));
 				socket.set(socketToSet);
 
 				writer.set(new BufferedWriter(new OutputStreamWriter(socketToSet.getOutputStream(), getCharset())));

--- a/src/main/java/com/github/loggly/log4j/helpers/SyslogTcpWriter64k.java
+++ b/src/main/java/com/github/loggly/log4j/helpers/SyslogTcpWriter64k.java
@@ -15,12 +15,12 @@ import javax.net.SocketFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * SyslogWriter64k is a wrapper around the java.net.DatagramSocket class so that it behaves like a java.io.Writer.
+ * SyslogWriter64k is a wrapper around the java.net.DatagramSocket class so that
+ * it behaves like a java.io.Writer.
  */
 @SuppressFBWarnings(value = "IMC_IMMATURE_CLASS_NO_TOSTRING",
 		justification = "Instance fields cannot be stringified nicely, therefore toString does not make that much sense.")
 public class SyslogTcpWriter64k extends SyslogWriter64k {
-
 	private final Optional<SocketFactory> socketFactory;
 
 	private final Optional<Duration> socketTimeout;
@@ -29,8 +29,7 @@ public class SyslogTcpWriter64k extends SyslogWriter64k {
 
 	private AtomicReference<BufferedWriter> writer = null;
 
-	public SyslogTcpWriter64k(
-			final String syslogHost,
+	public SyslogTcpWriter64k(final String syslogHost,
 			final Charset charset,
 			final Optional<SocketFactory> socketFactory,
 			final Optional<Duration> socketTimeout) {
@@ -57,7 +56,8 @@ public class SyslogTcpWriter64k extends SyslogWriter64k {
 				final Socket socketToSet = socketFactory.isPresent()
 						? socketFactory.get().createSocket(getSyslogHost(), getSyslogPort())
 						: new Socket(getSyslogHost(), getSyslogPort());
-				socketToSet.setSoTimeout(socketTimeout.map(duration -> (int) duration.get(ChronoUnit.MILLIS)).orElse(0));
+				socketToSet
+						.setSoTimeout(socketTimeout.map(duration -> (int) duration.get(ChronoUnit.MILLIS)).orElse(0));
 				socket.set(socketToSet);
 
 				writer.set(new BufferedWriter(new OutputStreamWriter(socketToSet.getOutputStream(), getCharset())));
@@ -118,7 +118,6 @@ public class SyslogTcpWriter64k extends SyslogWriter64k {
 
 	@FunctionalInterface
 	private interface IORunnable {
-
 		void run() throws IOException;
 	}
 }


### PR DESCRIPTION
This PR adds the possibility to configure the TCP socket timeout. In addition the default socket timeout is set to one minute. Before it was unspecified.

In addition I reworked some `volatile` on `Optional`.